### PR TITLE
Update Kue to 0.10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ redis-cli config set notify-keyspace-events Ex
 
 ## Installation
 ```
-$ npm install --save async lodash kue kue-scheduler
+$ npm install --save kue kue-scheduler
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Scheduling API is heavily inspired and borrowed from [agenda](https://github.com
 ## Requirements
 - Redis 2.8.0 or higher.
 
-- [kue 0.9.3+](https://github.com/Automattic/kue)
+- [kue 0.10.5+](https://github.com/Automattic/kue)
 
 - If `kue-scheduler` failed to enable keyspace notification(s) automatic, then you have to enable them using `redis-cli` 
 ```sh

--- a/index.js
+++ b/index.js
@@ -864,10 +864,10 @@ Queue.prototype.shutdown = function( /*fn, timeout, type*/ ) {
     //close _scheduler,
     // _lister and
     // _cli redis connctions
-    this._listener.end();
-    this._scheduler.end();
+    this._listener.quit();
+    this._scheduler.quit();
     if (this._cli) {
-        this._cli.end();
+        this._cli.quit();
     }
 
     //then call previous Queue shutdown

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     }, {
         "name": "risseraka",
         "github": "https://github.com/risseraka"
+    }, {
+        "name": "elyas-bhy",
+        "github": "https://github.com/elyas-bhy"
     }],
     "dependencies": {
         "async": "^1.5.0",
@@ -57,7 +60,7 @@
         "node-uuid": "^1.4.7"
     },
     "peerDependencies": {
-        "kue": "^0.9.6"
+        "kue": "^0.10.5"
     },
     "devDependencies": {
         "async": "^1.4.2",
@@ -67,7 +70,7 @@
         "grunt-contrib-jshint": "^0.11.3",
         "grunt-mocha-test": "^0.12.7",
         "jshint-stylish": "^2.1.0",
-        "kue": "^0.9.6",
+        "kue": "^0.10.5",
         "lodash": "^3.10.1",
         "mocha": "^2.3.4",
         "moment": "^2.10.6"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "kue": "^0.10.5"
     },
     "devDependencies": {
-        "async": "^1.4.2",
         "chai": "^3.4.1",
         "faker": "^3.0.1",
         "grunt": "^0.4.5",
@@ -71,7 +70,6 @@
         "grunt-mocha-test": "^0.12.7",
         "jshint-stylish": "^2.1.0",
         "kue": "^0.10.5",
-        "lodash": "^3.10.1",
         "mocha": "^2.3.4",
         "moment": "^2.10.6"
     }

--- a/test/schedule/every.spec.js
+++ b/test/schedule/every.spec.js
@@ -162,7 +162,7 @@ describe('Queue#every', function() {
             expect(runCount).to.equal(2);
             var ids = _.map(jobs, 'id');
             expect(ids[0]).to.equal(ids[1]);
-            Queue.remove(job, done);
+            Queue.remove({ unique: 'every_mail' }, done);
         }, 6000);
     });
 
@@ -245,7 +245,7 @@ describe('Queue#every', function() {
         setTimeout(function() {
             expect(runCount).to.equal(1);
             expect(_.map(jobs, 'id')).to.have.length(1);
-            Queue.remove(job, done);
+            Queue.remove({ unique: 'removed_email' }, done);
         }, 6000);
     });
 


### PR DESCRIPTION
I would like to highlight two important points in this PR:

- When shutting down the Redis clients, we need to use the [`client.quit()`](https://github.com/NodeRedis/node_redis#clientquit) method for graceful shutdown.
Before this PR, the code used [`client.end()`](https://github.com/NodeRedis/node_redis#clientendflush) which forcibly closed the connection, leading to potentially lost commands. Furthermore, this signature is now deprecated in the latest version of node-redis, `client.end(flush)` now takes a boolean to specify whether to flush pending commands. More info about it [here](https://github.com/NodeRedis/node_redis#clientendflush).

- The following snippet throws a Redis exception:
```javascript
var job = Queue
            .createJob('every', data)
            .attempts(3)
            .backoff(backoff)
            .priority('normal');

//schedule it to run every 2 seconds
Queue.every('2 seconds', job);

// At this level, there are several undefined attributes on the job instance,
// such as job.id and job.zid.
// These attributes are used by the underlying Kue module when issuing zrem commands,
// leading to a malformed command
Queue.remove(job, function () {});
```
This is the reason why I rewrote the specs to remove the job by its unique key. We should probably open a separate issue for this.