### PR TITLE
Change behavior of unique

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ Queue.prototype._computeNextRunTime = function(jobData, done) {
 
                 //return computed time
 
-                if (nextRun == 'Invalid Date'){
+                if ( isNaN( nextRun.getTime() ) ) {
                   nextRun = null;
                 }
                 after(null, nextRun);

--- a/index.js
+++ b/index.js
@@ -375,6 +375,10 @@ Queue.prototype._computeNextRunTime = function(jobData, done) {
                     new Date(lastRun.valueOf() + humanInterval(interval));
 
                 //return computed time
+
+                if (nextRun == 'Invalid Date'){
+                  nextRun = null;
+                }
                 after(null, nextRun);
             } catch (ex) {
                 //to allow parallel run with other interval parser
@@ -383,6 +387,7 @@ Queue.prototype._computeNextRunTime = function(jobData, done) {
         }
     }, function finish(error, results) {
         //was parsed as cron interval?
+
         if (!_.isNull(results.cron)) {
             return done(null, results.cron);
         }
@@ -933,7 +938,7 @@ kue.createQueue = function(options) {
  * @description remove existing job and its schedule
  * @param  {Number|Job|Object}   criteria a job id, job instance or criteria
  *                                        to be used
- * @param  {Function} [done]   a callback to invoke on success or error  
+ * @param  {Function} [done]   a callback to invoke on success or error
  */
 Queue.prototype.remove = Queue.prototype.removeJob = function(criteria, done) {
     //normalize callback

--- a/test/schedule/now.spec.js
+++ b/test/schedule/now.spec.js
@@ -49,12 +49,12 @@ describe('Queue#now', function() {
 
             finalize();
 
-            done();
         });
 
         //listen on success scheduling
         Queue.on('schedule success', function(job) {
             if (job.type === 'now') {
+
                 /*jshint camelcase:false */
                 expect(job.id).to.exist;
                 expect(job.type).to.equal('now');
@@ -73,6 +73,13 @@ describe('Queue#now', function() {
             .attempts(3)
             .backoff(backoff)
             .priority('normal');
+            //finalize was not always completing before done();
+        Queue.on('job complete', function(){
+                if(job.type === 'now'){
+                  setTimeout(function(){done();},3000);
+                }
+              });
+
 
         Queue.now(job);
     });
@@ -177,7 +184,7 @@ describe('Queue#now', function() {
 
             done();
 
-        }, 3000);
+        }, 5000);
     });
 
 


### PR DESCRIPTION
This Fixes #33. This still enforces kue-unique only allowing one job at a time with the same unique key to run, however it saves a new job for each run, so that history may be stored.