### PR TITLE
Unique use new jobs

### DIFF
--- a/examples/every_unique.js
+++ b/examples/every_unique.js
@@ -30,7 +30,7 @@ Queue.on('schedule error', function(error) {
 
 //listen on success scheduling
 Queue.on('schedule success', function(job) {
-    //a highly recommended place to attach 
+    //a highly recommended place to attach
     //job instance level events listeners
 
     job.on('complete', function(result) {
@@ -48,6 +48,15 @@ Queue.on('schedule success', function(job) {
     });
 
 });
+Queue.on('already scheduled', function(job){
+  console.log('job already scheduled' + job.id);
+});
+
+/*Queue.on('job complete', function(id, result){
+  console.log('Job completed with data ', result);
+
+});*/
+
 
 //prepare a job to perform
 //dont save it

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ Queue.prototype._isJobAlreadyScheduled = function(jobExpiryKey, done) {
 
             var alreadyScheduled = exists && active;
             done(null, alreadyScheduled);
+
         }
     });
 };
@@ -487,12 +488,18 @@ Queue.prototype._onJobKeyExpiry = function(jobExpiryKey) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                if(existJob.state() === 'complete' || existJob.state() === 'failed'){
                                   //unset the unique mapping for this.
                                   //existJob.inactive();
-                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err/*,deletedJobData */ ){
                                   //resave initial job, which should set new unique constraint.
+                                   if (err){
+                                     return next(err,null);
+                                   }
                                     job.save(function(error,newJob){
+                                      if (error){
+                                        return next(error,null);
+                                      }
                                           return next(null, newJob);
                                     });
                                   });
@@ -541,7 +548,7 @@ Queue.prototype._subscribe = function() {
     this
         ._listener
         .on('message', function(channel, jobExpiryKey) {
-
+            console.log('in message handler');
             //test if the event key is job expiry key
             //and emit `scheduler unknown job expiry key` if not
             if (!this._isJobExpiryKey(jobExpiryKey)) {
@@ -806,12 +813,18 @@ Queue.prototype.schedule = function(when, job) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                if(existJob.state() === 'complete' || existJob.state() === 'failed'){
                                   //unset the unique mapping for this.
                                   //existJob.inactive();
-                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err /*, deletedJobData*/){
                                   //resave initial job, which should set new unique constraint.
+                                  if (err){
+                                    return next(err,null);
+                                  }
                                     job.save(function(error,newJob){
+                                      if (error){
+                                        return next(error,null);
+                                      }
                                       return next(null, newJob);
                                     });
                                   });
@@ -897,13 +910,19 @@ Queue.prototype.now = function(job) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                if(existJob.state() === 'complete' || existJob.state() === 'failed'){
                                   //unset the unique mapping for this.
                                   //existJob.inactive();
-                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err/*,deletedJobData*/){
                                   //resave initial job, which should set new unique constraint.
+                                  if (err){
+                                    return next(err,null);
+                                  }
                                     job.save(function(error,newJob){
-                                        return next(null, job);
+                                      if (error){
+                                        return next(error,null);
+                                      }
+                                        return next(null, newJob);
                                     });
                                   });
                                 }
@@ -947,6 +966,10 @@ var shutdown = Queue.prototype.shutdown;
  */
 Queue.prototype.shutdown = function( /*fn, timeout, type*/ ) {
     //this refer to kue Queue instance context
+
+
+    //stop processing new expiry messages
+    this._listener.removeAllListeners('message');
 
     //unsubscribe to key expiry events
     this._listener.unsubscribe('__keyevent@0__:expired');

--- a/index.js
+++ b/index.js
@@ -432,7 +432,7 @@ Queue.prototype._onJobKeyExpiry = function(jobExpiryKey) {
 
       }
       else{
-        
+
         async.waterfall(
             [
 
@@ -487,10 +487,23 @@ Queue.prototype._onJobKeyExpiry = function(jobExpiryKey) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                existJob.inactive();
+                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                  //unset the unique mapping for this.
+                                  //existJob.inactive();
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  //resave initial job, which should set new unique constraint.
+                                    job.save(function(error,newJob){
+                                          return next(null, newJob);
+                                    });
+                                  });
+                                }
+                                else{
+                                  return next(null, existJob || job);
+                                }
                             }
-
-                            next(null, existJob || job);
+                            else{
+                                return next(null, existJob || job);
+                            }
                         }
                     });
                 }
@@ -793,10 +806,24 @@ Queue.prototype.schedule = function(when, job) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                existJob.inactive();
+                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                  //unset the unique mapping for this.
+                                  //existJob.inactive();
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  //resave initial job, which should set new unique constraint.
+                                    job.save(function(error,newJob){
+                                      return next(null, newJob);
+                                    });
+                                  });
+                                }
+                                else{
+                                  return next(null, existJob || job);
+                                }
+                            }
+                            else{
+                                return next(null, existJob || job);
                             }
 
-                            next(null, existJob || job);
                         }
                     });
                 }
@@ -870,10 +897,23 @@ Queue.prototype.now = function(job) {
                             //ensure unique job
                             if (existJob && existJob.alreadyExist) {
                                 //inactivate to signal next run
-                                existJob.inactive();
+                                if(existJob.state() !== 'complete' || existJob.state() !== 'failed'){
+                                  //unset the unique mapping for this.
+                                  //existJob.inactive();
+                                  kue.Job.removeUniqueJobData(existJob.id,function(err,deletedJobData){
+                                  //resave initial job, which should set new unique constraint.
+                                    job.save(function(error,newJob){
+                                        return next(null, job);
+                                    });
+                                  });
+                                }
+                                else{
+                                  return next(null, existJob || job);
+                                }
                             }
-
-                            next(null, existJob || job);
+                            else{
+                                next(null, existJob || job);
+                            }
                         }
                     });
                 }

--- a/test/schedule/every.spec.js
+++ b/test/schedule/every.spec.js
@@ -183,10 +183,10 @@ describe('Queue#every', function() {
         //wait for two jobs to be runned
         setTimeout(function() {
             expect(runCount).to.equal(2);
-            var ids = _.map(jobs, 'id');
-            expect(ids[0]).to.equal(ids[1]);
+            //var ids = _.map(jobs, 'id');
+            //expect(ids[0]).to.equal(ids[1]);
             Queue.remove({ unique: 'every_mail' }, done);
-        }, 6000);
+        }, 6005);
     });
 
     it('should be able to remove scheduled unique job', function(done) {

--- a/test/schedule/now.spec.js
+++ b/test/schedule/now.spec.js
@@ -102,6 +102,7 @@ describe('Queue#now', function() {
         Queue.process('unique_now', function(job, finalize) {
             //increament run counts
             runCount++;
+            console.log('running unique_now');
             ids.push(job.id);
 
             /*jshint camelcase:false */
@@ -179,8 +180,8 @@ describe('Queue#now', function() {
         setTimeout(function() {
 
             expect(runCount).to.equal(2);
-            expect(ids[0]).to.be.equal(ids[1]);
-            expect(existJob.id).to.equal(processedJob.id);
+            //expect(ids[0]).to.be.equal(ids[1]);
+            //expect(existJob.id).to.equal(processedJob.id);
 
             done();
 

--- a/test/schedule/schedule.spec.js
+++ b/test/schedule/schedule.spec.js
@@ -185,7 +185,7 @@ describe('Queue#schedule', function() {
         setTimeout(function() {
 
             expect(runCount).to.equal(1);
-            expect(existJob.id).to.equal(processedJob.id);
+            //expect(existJob.id).to.equal(processedJob.id);
 
             done();
         }, 5000);


### PR DESCRIPTION
Re-submitting new pull request for #33 

This changes unique scheduled jobs to use a new job for every run, while enforcing only one job with that unique constraint run at a time. 