### PR TITLE
Calling Queue.now(job) from within a job is failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -442,7 +442,7 @@ Queue.prototype._buildJob = function (jobDefinition, done) {
 
         //apply all job attributes into kue job instance
         // except for `progress`
-        _.without(_.keys(jobDefinition), 'progress')
+        _.without(_.keys(jobDefinition), 'progress', 'error')
           .forEach(function (attribute) {
             //if given job definition attribute
             //is one of job instance method


### PR DESCRIPTION
version used:
$ npm list --depth 0
megatron@0.0.1-1 C:\Users\ifruchte\Projects\megatron
├── kue@0.11.1
├── kue-scheduler@0.6.0
└── request@2.75.0

```javascript
var kue = require('kue-scheduler');
var Queue = kue.createQueue();
var request = require('request');

//create a job instance
var job = Queue
            .createJob('upm-scanning', { to: 'any'})
            .attempts(3)
            .backoff({ delay: 60000, type: 'fixed'})
            .priority('normal');

//schedule it to run every 5 seconds
Queue.every('5 seconds', job);


//somewhere process your scheduled jobs
Queue.process('upm-scanning', function(job, done) {
    console.log("ifruchte");
    url = "http://httpbin.org/get";

    request.get(url,  function (error, response, body) {
            if (!error && response.statusCode == 200) {
                data = JSON.parse(body) // Show the HTML for the Google homepage.
                console.log("data " + data["origin"] )

                //create a job instance
                var book_job = Queue
                    .createJob('booking-job', { to: 'any'})
                    .attempts(3)
                    .backoff({ delay: 60000, type: 'fixed'})
                    .priority('normal');

                Queue.now(book_job);
            }
        }
    )
    done();
});

Queue.process('booking-job', function(job, done) {
    console.log("booking-job");
    done();
});

```