### PR TITLE
(fix): Remove redlock, use warlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,25 +33,32 @@
     "url": "https://github.com/lykmapipo/kue-scheduler/issues"
   },
   "homepage": "https://github.com/lykmapipo/kue-scheduler",
-  "contributors": [{
-    "name": "lykmapipo",
-    "github": "https://github.com/lykmapipo"
-  }, {
-    "name": "keenondrums",
-    "github": "https://github.com/keenondrums"
-  }, {
-    "name": "throrin19",
-    "github": "https://github.com/throrin19"
-  }, {
-    "name": "KeKs0r",
-    "github": "https://github.com/KeKs0r"
-  }, {
-    "name": "risseraka",
-    "github": "https://github.com/risseraka"
-  }, {
-    "name": "elyas-bhy",
-    "github": "https://github.com/elyas-bhy"
-  }],
+  "contributors": [
+    {
+      "name": "lykmapipo",
+      "github": "https://github.com/lykmapipo"
+    },
+    {
+      "name": "keenondrums",
+      "github": "https://github.com/keenondrums"
+    },
+    {
+      "name": "throrin19",
+      "github": "https://github.com/throrin19"
+    },
+    {
+      "name": "KeKs0r",
+      "github": "https://github.com/KeKs0r"
+    },
+    {
+      "name": "risseraka",
+      "github": "https://github.com/risseraka"
+    },
+    {
+      "name": "elyas-bhy",
+      "github": "https://github.com/elyas-bhy"
+    }
+  ],
   "dependencies": {
     "async": "^2.1.4",
     "cron": "^1.1.1",
@@ -60,7 +67,7 @@
     "kue": "^0.11.5",
     "kue-unique": "^1.0.1",
     "lodash": "^4.17.2",
-    "redlock": "^2.1.0",
+    "node-redis-warlock": "^0.2.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Locks were not working for me when scheduling with `every()`. It resulted in jobs being executed multiple times. This adds the [warlock](https://github.com/TheDeveloper/warlock) dependency which solved this problem for me.