### PR TITLE
kue-scheduler next run calculation ignores timezone

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,20 +517,9 @@ Queue.prototype._computeNextRunTime = function (jobData, done) {
     //compute next run from cron interval
     cron: function (after) {
       try {
-        //last run of the job is now if not exist
-        var lastRun =
-          jobData.lastRun ? new Date(jobData.lastRun) : new Date();
-
         //compute next date from the cron interval
         var cronTime = new CronTime(interval, timezone);
-        var nextRun = cronTime._getNextDateFrom(lastRun);
-
-        // Handle cronTime giving back the same date
-        // for the next run time
-        if (nextRun.valueOf() === lastRun.valueOf()) {
-          nextRun =
-            cronTime._getNextDateFrom(new Date(lastRun.valueOf() + 1000));
-        }
+        var nextRun = cronTime.sendAt();
 
         //return computed time
         after(null, nextRun.toDate());

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "async": "^2.5.0",
-    "cron": "^1.2.1",
+    "cron": "^1.3.0",
     "date.js": "^0.3.1",
     "human-interval": "^0.1.6",
     "kue": "^0.11.6",

--- a/test/capability.spec.js
+++ b/test/capability.spec.js
@@ -184,7 +184,6 @@ describe('Queue Scheduling Capabilities', function () {
     it('should be able to compute next run from cron interval',
       function (done) {
         var lastRun = new Date();
-        lastRun.setSeconds(0);
 
         Queue._computeNextRunTime({
           reccurInterval: '* * * * * *',


### PR DESCRIPTION
Since the lastRun doesn't contain timezone information, _getNextDateFrom will just use server/system time to calculate the next run time. changing lastRun to be a moment() in order to use lastRun.tz(timezone) would just mimic the behavior of cronTime.sendAt() so I used that instead.
cronTime.sendAt() seems to also be incrementing the time by 1 second in order to make sure the returned value is in the future.