### PR TITLE
Added saveUniqueJob to Queue#schedule waterfall functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -958,7 +958,7 @@ Queue.prototype.schedule = function (when, job, done) {
     function saveUniqueJob(job, next) {
       // if a unique name is specified, save it with the job details
       if (job.data && job.data.unique) {
-        let jobDataKey = this._getJobDataKey(job.data.unique);
+        var jobDataKey = this._getJobDataKey(job.data.unique);
         this._saveJobData(jobDataKey, job, function (error) {
           next(error, job);
         });

--- a/index.js
+++ b/index.js
@@ -60,12 +60,12 @@ function ensureUniqueJob(job, done) {
     //assuming updated_at is in the past or now
     // updated_at is a built-in from kue.
     var timeSinceLastUpdate = now.getTime() - job.updated_at; // jshint ignore:line
-    var arbitraryThreshold = job.data.ttl + (job.data.ttl/2);
+    var arbitraryThreshold = job.data.ttl + (job.data.ttl / 2);
     var isStaleJob =
-    (job.state() === 'active' &&
+      (job.state() === 'active' &&
         timeSinceLastUpdate > arbitraryThreshold
       );
-    if (isCompletedOrFailedJob|| isStaleJob) {
+    if (isCompletedOrFailedJob || isStaleJob) {
       //resave job for next run
       //
       //NOTE!: We inactivate job to allow kue to queue the same job for next run.
@@ -286,8 +286,8 @@ Queue.prototype._getJobUUID = function (key) {
 
   var splits = key.split(':');
 
-  splits = _.filter(splits, function(o) { return o !== ''; });
-  if(splits.length > 0){
+  splits = _.filter(splits, function (o) { return o !== ''; });
+  if (splits.length > 0) {
     uuid = splits[splits.length - 1];
   }
 
@@ -338,7 +338,7 @@ Queue.prototype._saveJobData = function (jobDataKey, jobData, done) {
   //TODO make use of redis hash i.e redis.hmset(<key>, <data>);
   this
     ._scheduler
-    .set(jobDataKey, JSON.stringify(jobData), function (error /*, response*/ ) {
+    .set(jobDataKey, JSON.stringify(jobData), function (error /*, response*/) {
       done(error, jobData);
     });
 };
@@ -407,33 +407,33 @@ Queue.prototype._buildJob = function (jobDefinition, done) {
   //this refer to kue Queue instance context
 
   async.parallel({
-      isDefined: function (next) {
-        //is job definition provided
-        var isObject = _.isPlainObject(jobDefinition);
-        if (!isObject) {
-          next(new Error('Invalid job definition'));
-        } else {
-          next(null, true);
-        }
-      },
-      isValid: function (next) {
-        //check job for required attributes
-        //
-        //a valid job must have a type and
-        //associated data
-        var isValidJob = _.has(jobDefinition, 'type') &&
-          (
-            _.has(jobDefinition, 'data') &&
-            _.isPlainObject(jobDefinition.data)
-          );
-
-        if (!isValidJob) {
-          next(new Error('Missing job type or data'));
-        } else {
-          next(null, true);
-        }
+    isDefined: function (next) {
+      //is job definition provided
+      var isObject = _.isPlainObject(jobDefinition);
+      if (!isObject) {
+        next(new Error('Invalid job definition'));
+      } else {
+        next(null, true);
       }
     },
+    isValid: function (next) {
+      //check job for required attributes
+      //
+      //a valid job must have a type and
+      //associated data
+      var isValidJob = _.has(jobDefinition, 'type') &&
+        (
+          _.has(jobDefinition, 'data') &&
+          _.isPlainObject(jobDefinition.data)
+        );
+
+      if (!isValidJob) {
+        next(new Error('Missing job type or data'));
+      } else {
+        next(null, true);
+      }
+    }
+  },
     function finish(error, validations) {
       //is not well formatted job
       //back-off
@@ -954,7 +954,18 @@ Queue.prototype.schedule = function (when, job, done) {
 
     function ensureSingleUniqueJob(job, next) {
       ensureUniqueJob(job, next);
-    }
+    },
+    function saveUniqueJob(job, next) {
+      // if a unique name is specified, save it with the job details
+      if (job.data && job.data.unique) {
+        const jobDataKey = this._getJobDataKey(job.data.unique);
+        this._saveJobData(jobDataKey, job, function (error) {
+          next(error, job);
+        });
+      } else {
+        next(null, job);
+      }
+    }.bind(this)
 
   ], function (error, job) {
     //fire schedule error event
@@ -1086,7 +1097,7 @@ var shutdown = Queue.prototype.shutdown;
  * @return {Queue} for chaining
  * @api public
  */
-Queue.prototype.shutdown = function ( /*fn, timeout, type*/ ) {
+Queue.prototype.shutdown = function ( /*fn, timeout, type*/) {
   //this refer to kue Queue instance context
 
   //TODO ensure all client shutdown with waiting delay
@@ -1204,7 +1215,7 @@ kue.createQueue = function (options) {
  */
 Queue.prototype.remove = Queue.prototype.removeJob = function (criteria, done) {
   //normalize callback
-  done = done || function noop() {};
+  done = done || function noop() { };
 
   //compute criteria and job instance
   async.parallel({
@@ -1449,7 +1460,7 @@ Queue.prototype._getAllJobData = function (done) {
  */
 Queue.prototype.restore = function (done) {
   //ensure callback
-  done = _.isFunction(done) ? done : function () {};
+  done = _.isFunction(done) ? done : function () { };
 
   //fetch all job data
   this._getAllJobData(function (error, data) {

--- a/index.js
+++ b/index.js
@@ -958,7 +958,7 @@ Queue.prototype.schedule = function (when, job, done) {
     function saveUniqueJob(job, next) {
       // if a unique name is specified, save it with the job details
       if (job.data && job.data.unique) {
-        const jobDataKey = this._getJobDataKey(job.data.unique);
+        let jobDataKey = this._getJobDataKey(job.data.unique);
         this._saveJobData(jobDataKey, job, function (error) {
           next(error, job);
         });


### PR DESCRIPTION
Currently, the `unique` functionality is only useful for recurring jobs, since the `jobDataKey` is not mapped to the job's definition in Redis if the job is non-recurring (`ONCE`). 
The use case for this? Well, if we want to have some sort of management upon the jobs, such as updating some property in their definitions or even canceling them, it is not possible to do it in a "symmetrical" way - the job with its incremental ID is only set by `kue` on Redis once the job got processed for the first time, so we cannot use this ID if we want to cancel a scheduled job which has never been executed before. On the other hand, the `jobDataKey`, which is built using `this.options.prefix` and the `unique` property is not being set on Redis in case the job is non-recurring
So, mapping the job definition with `jobDataKey` in both `ONCE` and `RECCUR`-type jobs seems an appropriate way of doing this to me.

In this case, we could always access a job and even cancel it by using `queue._readJobData(key)` and then `job.remove()`.